### PR TITLE
fix bug gender column (with nan) as target role

### DIFF
--- a/hypex/reporters/aa.py
+++ b/hypex/reporters/aa.py
@@ -105,7 +105,6 @@ class AAPassedReporter(Reporter):
             names={c: c[: c.rfind("pass") - 1] for c in passed.columns}
         )
         passed = passed.replace("OK", 1).replace("NOT OK", 0)
-        passed = passed.astype({c: int for c in passed.columns})
         return passed
 
     def _detect_pass(self, analyzer_tables: dict[str, Dataset]):


### PR DESCRIPTION
fixed the bug that appeared when generating the resume in AAOutput if put TargetRole in the categorical column and this column has nan